### PR TITLE
Find nested Pods folder

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -19,7 +19,7 @@ const (
 	key = `{{ .Arch }}-cocoapods-cache-{{ checksum "**/Podfile.lock" }}`
 
 	// Cached path
-	path = "Pods"
+	path = "**/Pods"
 )
 
 type Input struct {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The step doesn't save anything if the `Pods` folder is not in the root. This is usually the case with cross-platform repos where the pods are located at `ios/Pods`.

### Changes

Fix cache path by looking for nested `Pods` directories too. The cache key already is working this way when looking for the `Podfile.lock` file, so this makes the behavior consistent.

### Investigation details

In theory, this change could match multiple folders named `Pods`, but a.) I don't think that is a valid setup, b.) even if it is, I see no issue adding all of them to the cache archive.

### Decisions

<!-- Please list decisions that were made for this change. -->
