### PR TITLE
Remove Auth Service token generation from e2e tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,19 +1,12 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-app:
-  envs:
-  # Shared secrets for testing, use a .bitrise.secrets.yml file to define these locally
-  - BITRISEIO_CACHE_SERVICE_URL: $BITRISEIO_CACHE_SERVICE_URL
-  - CACHE_API_CLIENT_SECRET: $CACHE_API_CLIENT_SECRET
-
 workflows:
   test_cocoapods:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample
     - BRANCH: main
     before_run:
-    - _generate_api_token
     - _setup
     steps:
     - change-workdir:
@@ -48,8 +41,6 @@ workflows:
     description: |
       Tests the case when there is nothing to compress based on the cache paths. The step returns early in this case
       with a 0 exit code
-    before_run:
-    - _generate_api_token
     steps:
     - change-workdir:
         title: Switch working dir to _tmp
@@ -74,26 +65,3 @@ workflows:
         - repository_url: $TEST_APP_URL
         - clone_into_dir: ./_tmp
         - branch: $BRANCH
-
-  _generate_api_token:
-    steps:
-    - script:
-        title: Generate API access token
-        description: Generate an expiring API token using $API_CLIENT_SECRET
-        inputs:
-        - content: |
-            #!/bin/env bash
-            set -e
-
-            json_response=$(curl --fail -X POST https://auth.services.bitrise.io/auth/realms/bitrise-services/protocol/openid-connect/token -k \
-                --data "client_id=bitrise-steps" \
-                --data "client_secret=$CACHE_API_CLIENT_SECRET" \
-                --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
-                --data "claim_token=eyJhcHBfaWQiOlsiY2FjaGUtc3RlcHMtdGVzdHMiXSwgIm9yZ19pZCI6WyJ0ZXN0LW9yZy1pZCJdLCAiYWJjc19hY2Nlc3NfZ3JhbnRlZCI6WyJ0cnVlIl19" \
-                --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
-                --data "audience=bitrise-services")
-
-            auth_token=$(echo $json_response | jq -r .access_token)
-
-            envman add --key BITRISEIO_ABCS_API_URL --value $BITRISEIO_CACHE_SERVICE_URL
-            envman add --key BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN --value $auth_token --sensitive


### PR DESCRIPTION
## Summary
- Remove the `_generate_api_token` utility workflow that requests UMA tokens from `auth.services.bitrise.io`
- Remove all `before_run` references to `_generate_api_token` from test workflows
- Remove now-unused app-level env vars (`CACHE_API_CLIENT_SECRET`, `BITRISEIO_CACHE_SERVICE_URL`, etc.)

**Note:** E2E tests will need `BITRISEIO_ABCS_API_URL` and `BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN` provided through a different mechanism for the cache steps to authenticate.

## Test plan
- [ ] Verify e2e tests still pass with the new token provisioning mechanism